### PR TITLE
Add login security settings page

### DIFF
--- a/Dadecore-theme/functions.php
+++ b/Dadecore-theme/functions.php
@@ -126,3 +126,4 @@ require get_template_directory() . '/inc/customizer.php';
 require get_template_directory() . '/inc/seo.php';
 require get_template_directory() . '/inc/security.php';
 require get_template_directory() . '/inc/cookie-consent.php';
+require get_template_directory() . '/inc/security-settings.php';

--- a/Dadecore-theme/inc/security-settings.php
+++ b/Dadecore-theme/inc/security-settings.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Login security settings page.
+ */
+
+/**
+ * Register the settings page under "Settings".
+ */
+function dadecore_register_security_settings_page() {
+    add_options_page(
+        __( 'Seguridad Login', 'dadecore-theme' ),
+        __( 'Seguridad Login', 'dadecore-theme' ),
+        'manage_options',
+        'dadecore-login-security',
+        'dadecore_render_security_settings_page'
+    );
+
+    register_setting( 'dadecore_security_settings', 'dadecore_login_slug', array(
+        'sanitize_callback' => 'sanitize_title_with_dashes',
+        'default'           => 'login',
+    ) );
+    register_setting( 'dadecore_security_settings', 'dadecore_max_login_attempts', array(
+        'sanitize_callback' => 'absint',
+        'default'           => 5,
+    ) );
+    register_setting( 'dadecore_security_settings', 'dadecore_lockout_time', array(
+        'sanitize_callback' => 'absint',
+        'default'           => 60,
+    ) );
+}
+add_action( 'admin_menu', 'dadecore_register_security_settings_page' );
+
+/**
+ * Flush rewrite rules when the login slug changes.
+ *
+ * @param mixed $old Old value.
+ * @param mixed $new New value.
+ */
+function dadecore_flush_rewrite_on_slug_change( $old, $new ) {
+    if ( $old !== $new ) {
+        flush_rewrite_rules();
+    }
+}
+add_action( 'update_option_dadecore_login_slug', 'dadecore_flush_rewrite_on_slug_change', 10, 2 );
+
+/**
+ * Output the settings page HTML.
+ */
+function dadecore_render_security_settings_page() {
+    ?>
+    <div class="wrap">
+        <h1><?php esc_html_e( 'Seguridad Login', 'dadecore-theme' ); ?></h1>
+        <form method="post" action="options.php">
+            <?php settings_fields( 'dadecore_security_settings' ); ?>
+            <table class="form-table" role="presentation">
+                <tr>
+                    <th scope="row">
+                        <label for="dadecore_login_slug"><?php esc_html_e( 'Login URL Slug', 'dadecore-theme' ); ?></label>
+                    </th>
+                    <td>
+                        <input name="dadecore_login_slug" type="text" id="dadecore_login_slug" value="<?php echo esc_attr( get_option( 'dadecore_login_slug', 'login' ) ); ?>" class="regular-text" />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">
+                        <label for="dadecore_max_login_attempts"><?php esc_html_e( 'Max Login Attempts', 'dadecore-theme' ); ?></label>
+                    </th>
+                    <td>
+                        <input name="dadecore_max_login_attempts" type="number" id="dadecore_max_login_attempts" value="<?php echo esc_attr( get_option( 'dadecore_max_login_attempts', 5 ) ); ?>" class="small-text" min="1" />
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">
+                        <label for="dadecore_lockout_time"><?php esc_html_e( 'Lockout Time (minutes)', 'dadecore-theme' ); ?></label>
+                    </th>
+                    <td>
+                        <input name="dadecore_lockout_time" type="number" id="dadecore_lockout_time" value="<?php echo esc_attr( get_option( 'dadecore_lockout_time', 60 ) ); ?>" class="small-text" min="1" />
+                    </td>
+                </tr>
+            </table>
+            <?php submit_button(); ?>
+        </form>
+    </div>
+    <?php
+}

--- a/Dadecore-theme/inc/security.php
+++ b/Dadecore-theme/inc/security.php
@@ -10,7 +10,7 @@ function dadecore_limit_login_attempts( $user, $username ) {
 
     $key       = 'dadecore_login_' . $_SERVER['REMOTE_ADDR'];
     $attempts  = (int) get_transient( $key );
-    $max       = (int) get_theme_mod( 'dadecore_max_login_attempts', 5 );
+    $max       = (int) get_option( 'dadecore_max_login_attempts', 5 );
 
     if ( $attempts >= $max ) {
         wp_die( __( 'Too many login attempts. Try again later.', 'dadecore-theme' ) );
@@ -27,7 +27,7 @@ function dadecore_track_failed_login( $username ) {
 
     $key      = 'dadecore_login_' . $_SERVER['REMOTE_ADDR'];
     $attempts = (int) get_transient( $key );
-    $minutes  = (int) get_theme_mod( 'dadecore_lockout_time', 60 );
+    $minutes  = (int) get_option( 'dadecore_lockout_time', 60 );
 
     set_transient( $key, $attempts + 1, $minutes * MINUTE_IN_SECONDS );
 }
@@ -41,13 +41,13 @@ function dadecore_security_headers() {
 add_action( 'send_headers', 'dadecore_security_headers' );
 
 function dadecore_login_rewrite() {
-    $slug = get_theme_mod( 'dadecore_login_slug', 'login' );
+    $slug = get_option( 'dadecore_login_slug', 'login' );
     add_rewrite_rule( '^' . $slug . '/?$', 'wp-login.php', 'top' );
 }
 add_action( 'init', 'dadecore_login_rewrite' );
 
 function dadecore_custom_login_url( $login_url, $redirect, $force_reauth ) {
-    $slug = get_theme_mod( 'dadecore_login_slug', 'login' );
+    $slug = get_option( 'dadecore_login_slug', 'login' );
     return home_url( '/' . trim( $slug, '/' ) . '/' );
 }
 add_filter( 'login_url', 'dadecore_custom_login_url', 10, 3 );


### PR DESCRIPTION
## Summary
- add admin page to manage login slug, max login attempts and lockout time
- load new security settings in security functions
- wire the settings page in the theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68632acad028832fa87020d9649637da