### PR TITLE
Fix missing content container markup

### DIFF
--- a/header.php
+++ b/header.php
@@ -45,4 +45,5 @@
         </nav>
     </header>
 
-<!-- Contenedor principal del contenido --
+<!-- Contenedor principal del contenido -->
+<div id="content" class="site-content site-wrapper">


### PR DESCRIPTION
## Summary
- start the content wrapper after the header in `header.php`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6865baf993cc832f8ac64dd1f8cd7f27