### PR TITLE
Fix footer closing tags

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -14,5 +14,9 @@
             );
             ?>
         </div>
+</footer>
+<!-- SOLUCIÓN FOOTER: cerramos #page después del footer para el layout flex -->
+</div><!-- #page -->
+<?php wp_footer(); ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- close `footer` and `#page` containers in `footer.php`
- ensure `wp_footer()` runs before closing `body` and `html`

## Testing
- `php -l footer.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865bb99166c832f836fa9994a4aaa09