### PR TITLE
Implement sticky footer using Flexbox

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -32,18 +32,28 @@
 
 /* --- Base Styles --- */
 
-html, body {
-    height: 100%;
+html {
+    height: 100%; /* Opcional si body tiene min-height: 100vh */
 }
 
-#page {
+body {
     min-height: 100vh;
+    display: flex; /* Hacemos body el contenedor flex principal */
+    flex-direction: column; /* Apilamos #page y otros posibles elementos directos */
+}
+
+#page { /* #page ahora es un hijo flex que puede crecer */
+    flex-grow: 1; /* Permitimos que #page crezca si body es el flex container */
     display: flex;
     flex-direction: column;
+    /* min-height: 100vh; Ya no es necesario aquí si body es el flex container principal y #page crece */
+    width: 100%; /* Aseguramos que #page ocupe todo el ancho disponible en el body flex */
 }
 
-#content {
-    flex: 1;
+#content { /* Este es el main#content.site-content */
+    flex-grow: 1; /* Renombrado de flex:1 a flex-grow:1 por claridad, el efecto es el mismo en este contexto */
+    padding-top: 80px; /* TODO: Ajustar este valor a la altura real del header fijo .site-header */
+                       /* Por ejemplo, crear una variable CSS --header-height y usarla aquí y en .site-header */
 }
 
 *, *::before, *::after {
@@ -898,8 +908,8 @@ img {
     justify-content: center;
     text-align: center;
     padding: 60px 20px;
-    margin-top: 100px; /* separa el contenido del header fijo */
-    min-height: calc(100vh - 160px); /* asegura el footer al final */
+    /* margin-top: 100px;  Este margin-top podría ser cubierto por el padding-top de #content, o ajustarse si es necesario */
+    /* min-height: calc(100vh - 160px); Ya no es necesario gracias a Flexbox en body/#page */
 }
 
 /* Responsive adjustments for blog pages */

--- a/header.php
+++ b/header.php
@@ -46,4 +46,4 @@
     </header>
 
 <!-- Contenedor principal del contenido -->
-<div id="content" class="site-content">
+<main id="content" class="site-content">


### PR DESCRIPTION
- Modified CSS (main.css):
  - Set body as the main flex container (min-height: 100vh, display: flex, flex-direction: column).
  - Configured #page to grow within body (flex-grow: 1, display: flex, flex-direction: column).
  - Ensured #content (main content area) grows to push footer down (flex-grow: 1).
  - Added padding-top to #content to account for the fixed header.
  - Removed page-specific min-height from 404.php styles, relying on the global Flexbox solution.
- Modified HTML (header.php):
  - Changed the main content wrapper from div#content to main#content for semantic correctness.
- Verified HTML structure in header.php and footer.php to ensure compatibility with the Flexbox solution.
- Confirmed 404.php structure is suitable for testing short content scenarios.

This ensures the footer stays at the bottom of the viewport on pages with short content and behaves normally on pages with long content.