### PR TITLE
Fix customizer preview dependencies

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -169,12 +169,12 @@ add_action( 'customize_register', 'dadecore_customize_register_404' );
 // ===================================================================
 
 function dadecore_customizer_live_preview() {
-    wp_enqueue_script( 
-        'dadecore-customizer-preview', 
-        get_template_directory_uri() . '/assets/js/customizer-preview.js', 
-        array( 'customize-preview' ), 
-        null, 
-        true 
+    wp_enqueue_script(
+        'dadecore-customizer-preview',
+        get_template_directory_uri() . '/assets/js/customizer-preview.js',
+        array( 'jquery', 'customize-preview' ),
+        null,
+        true
     );
 }
 add_action( 'customize_preview_init', 'dadecore_customizer_live_preview' );


### PR DESCRIPTION
## Summary
- include `jquery` dependency in the Customizer preview script

## Testing
- `php -l inc/customizer.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68660f2821a0832fabc77b7d79609815