### PR TITLE
Add customizer sections and output options

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -8,6 +8,8 @@
  */
 
 get_header();
+$blog_view   = get_theme_mod( 'dadecore_blog_view', 'grid' );
+$show_sidebar = get_theme_mod( 'dadecore_blog_sidebar', true );
 ?>
 
 <div class="site-main-wrapper container section-padding">
@@ -19,7 +21,7 @@ get_header();
             ?>
         </header><!-- .page-header -->
 
-        <div class="blog-posts-grid">
+        <div class="blog-posts-grid <?php echo ( 'list' === $blog_view ) ? 'blog-posts-list' : ''; ?>">
             <?php
             if ( have_posts() ) :
                 /* Start the Loop */
@@ -73,7 +75,7 @@ get_header();
         </div><!-- .blog-posts-grid -->
     </main><!-- #primary .content-area -->
 
-    <?php get_sidebar(); ?>
+    <?php if ( $show_sidebar ) { get_sidebar(); } ?>
 
 </div><!-- .site-main-wrapper -->
 <?php

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -209,7 +209,7 @@ img {
 }
 
 .site-header {
-    background-color: var(--glass-background);
+    background-color: var(--header-bg-color, var(--glass-background));
     backdrop-filter: blur(var(--glass-backdrop-blur));
     -webkit-backdrop-filter: blur(var(--glass-backdrop-blur));
     padding: 15px var(--padding-section-horizontal); /* Usar variable para padding horizontal */
@@ -223,6 +223,23 @@ img {
     justify-content: space-between;
     align-items: center;
     height: var(--header-height);
+}
+.no-sticky.site-header {
+    position: relative;
+}
+.logo-center .site-branding {
+    margin-left: auto;
+    margin-right: auto;
+}
+.nav-center .main-navigation {
+    margin-left: auto;
+    margin-right: auto;
+}
+.nav-left .main-navigation {
+    margin-right: auto;
+}
+.nav-right .main-navigation {
+    margin-left: auto;
 }
 
 .site-branding {
@@ -266,7 +283,7 @@ img {
 }
 
 .main-navigation a {
-    color: var(--color-white);
+    color: var(--header-text-color, var(--color-white));
     font-weight: bold;
     font-size: var(--wp--preset--font-size--normal, 1em); /* Ajustar según sea necesario */
     position: relative;
@@ -540,6 +557,33 @@ img {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 30px;
+}
+
+.blog-posts-list {
+    display: block;
+}
+.blog-posts-list .blog-post-item {
+    display: flex;
+    gap: 20px;
+    margin-bottom: 30px;
+}
+.blog-posts-list .post-thumbnail {
+    flex: 0 0 30%;
+}
+.blog-posts-list .entry-summary {
+    flex: 1;
+}
+
+.social-links-list {
+    list-style: none;
+    display: flex;
+    gap: 10px;
+    padding: 0;
+    margin: 0;
+}
+.social-links-list a {
+    color: var(--header-text-color, var(--color-white));
+    font-size: 1.2em;
 }
 
 .blog-post-item .post-thumbnail img {

--- a/assets/js/customizer-preview.js
+++ b/assets/js/customizer-preview.js
@@ -14,6 +14,16 @@
             document.documentElement.style.setProperty('--color-dark-blue-bg', newval);
         });
     });
+    wp.customize('dadecore_header_bg_color', function(value) {
+        value.bind(function(newval) {
+            document.documentElement.style.setProperty('--header-bg-color', newval);
+        });
+    });
+    wp.customize('dadecore_header_text_color', function(value) {
+        value.bind(function(newval) {
+            document.documentElement.style.setProperty('--header-text-color', newval);
+        });
+    });
 
     wp.customize('dadecore_404_custom_title', function(value) {
         value.bind(function(newval) {
@@ -23,6 +33,11 @@
     wp.customize('dadecore_404_custom_message', function(value) {
         value.bind(function(newval) {
             $('.error-404 p').first().text(newval);
+        });
+    });
+    wp.customize('dadecore_footer_custom_text', function(value) {
+        value.bind(function(newval) {
+            $('.custom-footer-text').text(newval);
         });
     });
 })(jQuery);

--- a/footer.php
+++ b/footer.php
@@ -1,7 +1,7 @@
     </main> <!-- #content -->
 
     <footer id="colophon" class="site-footer">
-        <?php if ( is_active_sidebar( 'footer-1' ) || is_active_sidebar( 'footer-2' ) || is_active_sidebar( 'footer-3' ) ) : ?>
+        <?php if ( get_theme_mod( 'dadecore_footer_show_widgets', true ) && ( is_active_sidebar( 'footer-1' ) || is_active_sidebar( 'footer-2' ) || is_active_sidebar( 'footer-3' ) ) ) : ?>
             <div class="footer-widgets-area">
                 <div class="container">
                     <div class="footer-widgets-grid">
@@ -39,6 +39,14 @@
                 );
                 ?>
                 <p>&copy; <?php echo date_i18n( 'Y' ); ?> <?php bloginfo( 'name' ); ?>. <?php esc_html_e( 'All rights reserved.', 'dadecore-theme' ); ?></p>
+                <?php if ( get_theme_mod( 'dadecore_footer_custom_text' ) ) : ?>
+                    <p class="custom-footer-text"><?php echo wp_kses_post( get_theme_mod( 'dadecore_footer_custom_text' ) ); ?></p>
+                <?php endif; ?>
+                <?php if ( function_exists( 'dadecore_has_social_links' ) && dadecore_has_social_links() ) : ?>
+                    <div class="footer-social-links">
+                        <?php dadecore_output_social_links(); ?>
+                    </div>
+                <?php endif; ?>
             </div>
         </div><!-- .site-info -->
     </footer><!-- #colophon -->

--- a/functions.php
+++ b/functions.php
@@ -88,8 +88,11 @@ function dadecore_theme_scripts() {
 	// Fuentes de Google (Inter y Poppins) - Mantenido como fallback o si las fuentes locales no se usan.
 	// Si se usan fuentes locales exclusivamente desde theme.json, esta sección podría eliminarse.
 	// Precarga para optimización
-	wp_enqueue_style( 'google-fonts', 'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@400;700&display=swap', array(), null ); // No necesita versión, es CDN
-	wp_style_add_data( 'google-fonts', 'precache', true );
+    wp_enqueue_style( 'google-fonts', 'https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Poppins:wght@400;700&display=swap', array(), null ); // No necesita versión, es CDN
+    wp_style_add_data( 'google-fonts', 'precache', true );
+
+    // Dashicons for frontend icons (social links)
+    wp_enqueue_style( 'dashicons' );
 
 
 	// Script principal del tema

--- a/header.php
+++ b/header.php
@@ -12,7 +12,15 @@
 
 <!-- Layout principal del sitio (Flex vertical) -->
 <div id="page">
-    <header id="masthead" class="site-header">
+    <?php
+    $logo_pos   = get_theme_mod( 'dadecore_logo_position', 'left' );
+    $nav_align  = get_theme_mod( 'dadecore_nav_alignment', 'right' );
+    $sticky     = get_theme_mod( 'dadecore_enable_sticky_header', true );
+    $header_cls = 'site-header';
+    $header_cls .= $sticky ? '' : ' no-sticky';
+    $header_cls .= ' logo-' . $logo_pos . ' nav-' . $nav_align;
+    ?>
+    <header id="masthead" class="<?php echo esc_attr( $header_cls ); ?>">
         <div class="site-branding">
             <?php if ( is_front_page() && is_home() ) : ?>
                 <h1 class="site-title">
@@ -43,6 +51,11 @@
             ) );
             ?>
         </nav>
+        <?php if ( function_exists( 'dadecore_has_social_links' ) && dadecore_has_social_links() ) : ?>
+            <div class="header-social-links">
+                <?php dadecore_output_social_links(); ?>
+            </div>
+        <?php endif; ?>
     </header>
     <?php
     if ( is_active_sidebar( 'ads-header' ) ) : ?>

--- a/home.php
+++ b/home.php
@@ -13,6 +13,8 @@
  */
 
 get_header();
+$blog_view   = get_theme_mod( 'dadecore_blog_view', 'grid' );
+$show_sidebar = get_theme_mod( 'dadecore_blog_sidebar', true );
 ?>
 
     <div id="primary" class="site-main">
@@ -20,7 +22,7 @@ get_header();
             <header class="page-header">
                 <h1 class="page-title section-title"><?php single_post_title(); ?></h1>
                 <p class="section-subtitle">Explora nuestras últimas publicaciones y recursos.</p>
-            </header><div class="blog-posts-grid">
+            </header><div class="blog-posts-grid <?php echo ( 'list' === $blog_view ) ? 'blog-posts-list' : ''; ?>">
                 <?php
                 if ( have_posts() ) :
                     /* Start the Loop */
@@ -64,5 +66,7 @@ get_header();
     </div><!-- #primary -->
 
 <?php
-get_sidebar();
+if ( $show_sidebar ) {
+    get_sidebar();
+}
 get_footer();

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -28,6 +28,217 @@ function dadecore_customizer_live_preview() {
 }
 add_action( 'customize_preview_init', 'dadecore_customizer_live_preview' );
 
+// ===================================================================
+// ✅ BLOQUE 4: Opciones extra de tema (Header, Blog, Single, Footer, Social)
+// ===================================================================
+
+function dadecore_customize_register_extra_sections( $wp_customize ) {
+    // -----------------------------
+    // Header & Navigation
+    // -----------------------------
+    $wp_customize->add_section( 'dadecore_header_nav', array(
+        'title'    => __( 'Header & Navigation', 'dadecore-theme' ),
+        'priority' => 25,
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_logo_position', array(
+        'default'           => 'left',
+        'sanitize_callback' => 'sanitize_text_field',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_logo_position', array(
+        'label'   => __( 'Logo position', 'dadecore-theme' ),
+        'section' => 'dadecore_header_nav',
+        'type'    => 'radio',
+        'choices' => array(
+            'left'   => __( 'Left', 'dadecore-theme' ),
+            'center' => __( 'Center', 'dadecore-theme' ),
+        ),
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_nav_alignment', array(
+        'default'           => 'right',
+        'sanitize_callback' => 'sanitize_text_field',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_nav_alignment', array(
+        'label'   => __( 'Navbar alignment', 'dadecore-theme' ),
+        'section' => 'dadecore_header_nav',
+        'type'    => 'radio',
+        'choices' => array(
+            'left'   => __( 'Left', 'dadecore-theme' ),
+            'center' => __( 'Center', 'dadecore-theme' ),
+            'right'  => __( 'Right', 'dadecore-theme' ),
+        ),
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_enable_sticky_header', array(
+        'default'           => true,
+        'sanitize_callback' => 'wp_validate_boolean',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_enable_sticky_header', array(
+        'label'   => __( 'Enable sticky header', 'dadecore-theme' ),
+        'section' => 'dadecore_header_nav',
+        'type'    => 'checkbox',
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_header_bg_color', array(
+        'default'           => '#0A1128',
+        'sanitize_callback' => 'sanitize_hex_color',
+        'transport'         => 'postMessage',
+    ) );
+    $wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'dadecore_header_bg_color', array(
+        'label'    => __( 'Header background color', 'dadecore-theme' ),
+        'section'  => 'dadecore_header_nav',
+        'settings' => 'dadecore_header_bg_color',
+    ) ) );
+
+    $wp_customize->add_setting( 'dadecore_header_text_color', array(
+        'default'           => '#ffffff',
+        'sanitize_callback' => 'sanitize_hex_color',
+        'transport'         => 'postMessage',
+    ) );
+    $wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'dadecore_header_text_color', array(
+        'label'    => __( 'Header text color', 'dadecore-theme' ),
+        'section'  => 'dadecore_header_nav',
+        'settings' => 'dadecore_header_text_color',
+    ) ) );
+
+    // -----------------------------
+    // Blog Layout
+    // -----------------------------
+    $wp_customize->add_section( 'dadecore_blog_layout', array(
+        'title'    => __( 'Blog Layout', 'dadecore-theme' ),
+        'priority' => 40,
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_blog_sidebar', array(
+        'default'           => true,
+        'sanitize_callback' => 'wp_validate_boolean',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_blog_sidebar', array(
+        'label'   => __( 'Display sidebar', 'dadecore-theme' ),
+        'section' => 'dadecore_blog_layout',
+        'type'    => 'checkbox',
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_blog_excerpt_length', array(
+        'default'           => 20,
+        'sanitize_callback' => 'absint',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_blog_excerpt_length', array(
+        'label'       => __( 'Excerpt length (words)', 'dadecore-theme' ),
+        'section'     => 'dadecore_blog_layout',
+        'type'        => 'number',
+        'input_attrs' => array( 'min' => 5, 'max' => 100 ),
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_blog_view', array(
+        'default'           => 'grid',
+        'sanitize_callback' => 'sanitize_text_field',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_blog_view', array(
+        'label'   => __( 'Blog view', 'dadecore-theme' ),
+        'section' => 'dadecore_blog_layout',
+        'type'    => 'radio',
+        'choices' => array(
+            'grid' => __( 'Grid', 'dadecore-theme' ),
+            'list' => __( 'List', 'dadecore-theme' ),
+        ),
+    ) );
+
+    // -----------------------------
+    // Single Post
+    // -----------------------------
+    $wp_customize->add_section( 'dadecore_single_post', array(
+        'title'    => __( 'Single Post', 'dadecore-theme' ),
+        'priority' => 45,
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_single_show_meta', array(
+        'default'           => true,
+        'sanitize_callback' => 'wp_validate_boolean',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_single_show_meta', array(
+        'label'   => __( 'Show post metadata', 'dadecore-theme' ),
+        'section' => 'dadecore_single_post',
+        'type'    => 'checkbox',
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_single_sidebar_position', array(
+        'default'           => 'right',
+        'sanitize_callback' => 'sanitize_text_field',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_single_sidebar_position', array(
+        'label'   => __( 'Sidebar position', 'dadecore-theme' ),
+        'section' => 'dadecore_single_post',
+        'type'    => 'radio',
+        'choices' => array(
+            'left'  => __( 'Left', 'dadecore-theme' ),
+            'right' => __( 'Right', 'dadecore-theme' ),
+        ),
+    ) );
+
+    // -----------------------------
+    // Footer
+    // -----------------------------
+    $wp_customize->add_section( 'dadecore_footer', array(
+        'title'    => __( 'Footer', 'dadecore-theme' ),
+        'priority' => 50,
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_footer_show_widgets', array(
+        'default'           => true,
+        'sanitize_callback' => 'wp_validate_boolean',
+        'transport'         => 'refresh',
+    ) );
+    $wp_customize->add_control( 'dadecore_footer_show_widgets', array(
+        'label'   => __( 'Display footer widgets', 'dadecore-theme' ),
+        'section' => 'dadecore_footer',
+        'type'    => 'checkbox',
+    ) );
+
+    $wp_customize->add_setting( 'dadecore_footer_custom_text', array(
+        'default'           => '',
+        'sanitize_callback' => 'wp_kses_post',
+        'transport'         => 'postMessage',
+    ) );
+    $wp_customize->add_control( 'dadecore_footer_custom_text', array(
+        'label'   => __( 'Custom footer text', 'dadecore-theme' ),
+        'section' => 'dadecore_footer',
+        'type'    => 'text',
+    ) );
+
+    // -----------------------------
+    // Social Links
+    // -----------------------------
+    $wp_customize->add_section( 'dadecore_social_links', array(
+        'title'    => __( 'Social Links', 'dadecore-theme' ),
+        'priority' => 55,
+    ) );
+
+    $networks = array( 'facebook', 'twitter', 'instagram', 'linkedin', 'github' );
+    foreach ( $networks as $network ) {
+        $wp_customize->add_setting( 'dadecore_social_' . $network, array(
+            'default'           => '',
+            'sanitize_callback' => 'esc_url_raw',
+            'transport'         => 'postMessage',
+        ) );
+        $wp_customize->add_control( 'dadecore_social_' . $network, array(
+            'label'   => ucfirst( $network ) . ' URL',
+            'section' => 'dadecore_social_links',
+            'type'    => 'url',
+        ) );
+    }
+}
+add_action( 'customize_register', 'dadecore_customize_register_extra_sections' );
+
 function dadecore_customizer_css() {
     $accent = get_theme_mod( 'dadecore_accent_color', '#00FFC2' );
     echo '<style>:root{--color-green-tech:' . esc_attr( $accent ) . ';}</style>';
@@ -95,11 +306,15 @@ function dadecore_customizer_css_variables() {
     $accent = get_theme_mod( 'dadecore_accent_color', '#00FFC2' );
     $accent_secondary = get_theme_mod( 'dadecore_accent_secondary_color', '#64FFDA' );
     $bg_color = get_theme_mod( 'dadecore_bg_color', '#0A1128' );
+    $header_bg = get_theme_mod( 'dadecore_header_bg_color', '#0A1128' );
+    $header_text = get_theme_mod( 'dadecore_header_text_color', '#ffffff' );
 
     echo '<style>:root {';
     echo '--color-accent: ' . esc_attr( $accent ) . ';';
     echo '--color-accent-secondary: ' . esc_attr( $accent_secondary ) . ';';
     echo '--color-dark-blue-bg: ' . esc_attr( $bg_color ) . ';';
+    echo '--header-bg-color: ' . esc_attr( $header_bg ) . ';';
+    echo '--header-text-color: ' . esc_attr( $header_text ) . ';';
     echo '}</style>';
 }
 add_action( 'wp_head', 'dadecore_customizer_css_variables' );

--- a/inc/template-helpers.php
+++ b/inc/template-helpers.php
@@ -54,4 +54,51 @@ function dadecore_get_fallback_image_url() {
     return get_template_directory_uri() . '/assets/img/placeholder-project1.jpg'; // Re-use an existing placeholder
 }
 
+/**
+ * Return an array of social links defined in the Customizer.
+ */
+function dadecore_get_social_links() {
+    $networks = array( 'facebook', 'twitter', 'instagram', 'linkedin', 'github' );
+    $links    = array();
+    foreach ( $networks as $network ) {
+        $url = get_theme_mod( 'dadecore_social_' . $network );
+        if ( $url ) {
+            $links[ $network ] = esc_url( $url );
+        }
+    }
+    return $links;
+}
+
+/**
+ * Echo list of social links.
+ */
+function dadecore_output_social_links() {
+    $links = dadecore_get_social_links();
+    if ( empty( $links ) ) {
+        return;
+    }
+    echo '<ul class="social-links-list">';
+    foreach ( $links as $network => $url ) {
+        echo '<li class="social-link social-' . esc_attr( $network ) . '"><a href="' . esc_url( $url ) . '" target="_blank" rel="nofollow"><span class="dashicons dashicons-' . esc_attr( $network ) . '"></span></a></li>';
+    }
+    echo '</ul>';
+}
+
+/**
+ * Custom excerpt length based on Customizer setting.
+ */
+function dadecore_custom_excerpt_length( $length ) {
+    $custom = get_theme_mod( 'dadecore_blog_excerpt_length', 20 );
+    return absint( $custom );
+}
+add_filter( 'excerpt_length', 'dadecore_custom_excerpt_length' );
+
+/**
+ * Helper to check if any social link exists.
+ */
+function dadecore_has_social_links() {
+    $links = dadecore_get_social_links();
+    return ! empty( $links );
+}
+
 ?>

--- a/index.php
+++ b/index.php
@@ -13,6 +13,8 @@
  */
 
 get_header();
+$blog_view   = get_theme_mod( 'dadecore_blog_view', 'grid' );
+$show_sidebar = get_theme_mod( 'dadecore_blog_sidebar', true );
 ?>
 
 <div class="site-main-wrapper container section-padding">
@@ -23,7 +25,7 @@ get_header();
             </header>
         <?php endif; ?>
 
-        <div class="blog-posts-grid">
+        <div class="blog-posts-grid <?php echo ( 'list' === $blog_view ) ? 'blog-posts-list' : ''; ?>">
             <?php
             if ( have_posts() ) :
                 /* Start the Loop */
@@ -81,7 +83,7 @@ get_header();
         </div><!-- .blog-posts-grid -->
     </main><!-- #primary .content-area -->
 
-    <?php get_sidebar(); ?>
+    <?php if ( $show_sidebar ) { get_sidebar(); } ?>
 
 </div><!-- .site-main-wrapper -->
 <?php

--- a/search.php
+++ b/search.php
@@ -8,6 +8,8 @@
  */
 
 get_header();
+$blog_view   = get_theme_mod( 'dadecore_blog_view', 'grid' );
+$show_sidebar = get_theme_mod( 'dadecore_blog_sidebar', true );
 ?>
 
 <div class="site-main-wrapper container section-padding">
@@ -21,7 +23,7 @@ get_header();
             </h1>
         </header><!-- .page-header -->
 
-        <div class="blog-posts-grid">
+        <div class="blog-posts-grid <?php echo ( 'list' === $blog_view ) ? 'blog-posts-list' : ''; ?>">
             <?php
             if ( have_posts() ) :
                 /* Start the Loop */
@@ -77,7 +79,7 @@ get_header();
         </div><!-- .blog-posts-grid -->
     </main><!-- #primary .content-area -->
 
-    <?php get_sidebar(); ?>
+    <?php if ( $show_sidebar ) { get_sidebar(); } ?>
 
 </div><!-- .site-main-wrapper -->
 <?php

--- a/single.php
+++ b/single.php
@@ -8,9 +8,11 @@
  */
 
 get_header();
+$show_meta    = get_theme_mod( 'dadecore_single_show_meta', true );
+$sidebar_pos  = get_theme_mod( 'dadecore_single_sidebar_position', 'right' );
 ?>
 
-<div class="site-main-wrapper container section-padding">
+<div class="site-main-wrapper container section-padding sidebar-<?php echo esc_attr( $sidebar_pos ); ?>">
     <main id="primary" class="site-main content-area">
         <?php
         while ( have_posts() ) :
@@ -23,9 +25,9 @@ get_header();
                 <div class="container">
                     <header class="entry-header">
                         <?php the_title( '<h1 class="entry-title section-title">', '</h1>' ); ?>
+                        <?php if ( $show_meta ) : ?>
                         <div class="entry-meta section-subtitle">
                             <?php
-                            // Información del post: autor, fecha, categorías
                             printf(
                                 esc_html__( 'Publicado el %1$s por %2$s en %3$s', 'dadecore-theme' ),
                                 '<time datetime="' . esc_attr( get_the_date( 'c' ) ) . '">' . esc_html( get_the_date() ) . '</time>',
@@ -34,6 +36,7 @@ get_header();
                             );
                             ?>
                         </div>
+                        <?php endif; ?>
                     </header><?php if ( has_post_thumbnail() ) : ?>
                         <div class="post-thumbnail-single">
                             <?php the_post_thumbnail( 'large' ); // Puedes usar 'full', 'large', 'medium', etc. ?>


### PR DESCRIPTION
## Summary
- extend Customizer with options for header, blog, single posts, footer and social links
- output new settings in header, footer and templates
- support social links helpers
- adjust styles and JS for live preview

## Testing
- `php` command not available, so PHP linting was skipped

------
https://chatgpt.com/codex/tasks/task_e_6866132983b4832fa833cf60885ece50